### PR TITLE
Adds Helper that allows adding custom Strings to the query

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Elastic::ESQL.from('sample_data').limit(2).sort('@timestamp').descending.to_s
 
 ## API
 
-Reference documentation can be generated with YARD docs in `./doc` by running `rake yard`.
+📜 Reference documentation can be generated with YARD docs in `./doc` by running `rake yard`.
 
 ### Source Commands (FROM, ROW, SHOW)
 
@@ -163,6 +163,23 @@ You can chain WHERE commands which will be joined with `AND` as is expected in E
 ```ruby
 Elastic::ESQL.from('sample').where('first_name == "Juan"').where('last_name == "Perez"').where('age > 18').query
 # => "FROM sample | WHERE first_name == \"Juan\" AND last_name == \"Perez\" AND age > 18"
+```
+
+### Custom Strings
+
+You can use the `custom` function to add custom Strings to the query. This will concatenate the strings at the end of the query. It will add them as they're sent to the function, without adding any pipe characters. They'll be joined to the rest of the query by a space character.
+
+```ruby
+esql = Elastic::ESQL.from('sample_data')
+esql.custom('| MY_VALUE = "test value"').to_s
+# => 'FROM sample_data | MY_VALUE = "test value"'
+```
+
+Chaining `custom` functions:
+
+```ruby
+esql.custom('| MY_VALUE = "test value"').custom('| ANOTHER, VALUE')
+'FROM sample_data | MY_VALUE = "test value" | ANOTHER, VALUE'
 ```
 
 ## Usage with elasticsearch-ruby

--- a/lib/elastic/custom.rb
+++ b/lib/elastic/custom.rb
@@ -1,0 +1,35 @@
+# Licensed to Elasticsearch B.V. under one or more contributor
+# license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright
+# ownership. Elasticsearch B.V. licenses this file to you under
+# the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+module Elastic
+  # Helpers that allows adding custom Strings to the query.
+  module Custom
+    # This will concatenate custom strings at the end of the query. It will add them as they're sent
+    # to the function, without adding any pipe characters. They'll be joined to the rest of the
+    # query by a space character.
+    #
+    # @param [String] custom String to add to the query
+    # @example
+    #   esql.custom('| MY_VALUE = "test value"')
+    #   esql.custom('| MY_VALUE = "test"').custom('| OTHER, VALUES')
+    #
+    def custom(string)
+      @custom << string
+      self
+    end
+  end
+end

--- a/spec/custom_string_spec.rb
+++ b/spec/custom_string_spec.rb
@@ -1,0 +1,34 @@
+# Licensed to Elasticsearch B.V. under one or more contributor
+# license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright
+# ownership. Elasticsearch B.V. licenses this file to you under
+# the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+require 'spec_helper'
+
+describe Elastic::ESQL do
+  context 'Custom String' do
+    let(:esql) { Elastic::ESQL.from('sample_data') }
+
+    it 'accepts a custom string as a parameter' do
+      esql.custom('| MY_VALUE = "test value"')
+      expect(esql.query).to eq 'FROM sample_data | MY_VALUE = "test value"'
+    end
+
+    it 'accepts chaining custom strings' do
+      esql.custom('| MY_VALUE = "test value"').custom('| ANOTHER, VALUE')
+      expect(esql.query).to eq 'FROM sample_data | MY_VALUE = "test value" | ANOTHER, VALUE'
+    end
+  end
+end


### PR DESCRIPTION
This will concatenate custom strings at the end of the query. It will add them as they're sent to the function, without adding any pipe characters. They'll be joined to the rest of the query by a space character.