### PR TITLE
Updates functions to be mutable/non-mutable

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,10 +5,17 @@ This gem allows you to build [ES|QL](https://www.elastic.co/docs/explore-analyze
 > [!IMPORTANT]
 > This library is in active development and the final API hasn't been completed yet. If you have any feedback on the current API or general usage, please don't hesitate to [open a new issue](https://github.com/elastic/esql-ruby/issues).
 
-You can instantiate a query with any [source command](https://www.elastic.co/docs/reference/query-languages/esql/esql-commands#esql-source-commands), like `from`, `row` or `show`:
+You can instantiate a query with a [source command](https://www.elastic.co/docs/reference/query-languages/esql/esql-commands#esql-source-commands), like `from` or `row`:
 
 ```ruby
 Elastic::ESQL.from('sample')
+```
+
+The `show` command will always return the String `'SHOW INFO'`:
+
+```ruby
+Elastic::ESQL.show
+# => "SHOW INFO"
 ```
 
 Build the query by chaining ES|QL methods. You can see the generated query with `.to_s`:
@@ -16,6 +23,17 @@ Build the query by chaining ES|QL methods. You can see the generated query with 
 ```ruby
 Elastic::ESQL.from('sample_data').limit(2).sort('@timestamp').descending.to_s
 # => "FROM sample_data | LIMIT 2 | SORT @timestamp DESC"
+```
+
+To mutate an instantiated query object, you can use the `!` equivalents of each function:
+
+```ruby
+query = Elastic::ESQL.from('sample_data')
+query.to_s
+# => "FROM sample_data"
+query.limit!(2).sort!('@timestamp')
+query.to_s
+# => "FROM sample_data | LIMIT 2 | SORT @timestamp"
 ```
 
 ## API
@@ -48,14 +66,14 @@ While `row` and `from` can be chained with other functions to build a complex qu
 
 ```ruby
 query = Elastic::ESQL.from('sample_data')
-query.dissect('a', '%{date} - %{msg} - %{ip}').to_s
+query.dissect!('a', '%{date} - %{msg} - %{ip}').to_s
 # => 'FROM sample_data | DISSECT a """%{date} - %{msg} - %{ip}"""'
 ```
 
 You can also specify a separator, a string used as the separator between appended values, when using the append modifier:
 
 ```ruby
-query.dissect('a', '%{date} - %{msg} - %{ip}', ',').to_s
+query.dissect!('a', '%{date} - %{msg} - %{ip}', ',').to_s
 # => 'FROM sample_data | DISSECT a """%{date} - %{msg} - %{ip}""" APPEND_SEPARATOR=","'
 ```
 
@@ -64,7 +82,7 @@ query.dissect('a', '%{date} - %{msg} - %{ip}', ',').to_s
 The [DROP](https://www.elastic.co/docs/reference/query-languages/esql/commands/processing-commands#esql-drop) processing command removes one or more columns.
 
 ```ruby
-query.drop('column1', 'column2').to_s
+query.drop!('column1', 'column2').to_s
 # => 'FROM sample_data | DROP column1, column2'
 ```
 
@@ -74,13 +92,13 @@ query.drop('column1', 'column2').to_s
 
 ```ruby
 esql = Elastic::ESQL.from('sample_data')
-esql.enrich('policy')
+esql.enrich!('policy')
 ```
 
 Once you call `enrich` on an `Elastic::ESQL` object, you can chain `on` and `with` to it.
 
 ```ruby
-esql.enrich('policy').on('a').with({ name: 'language_name' })
+esql.enrich!('policy').on('a').with({ name: 'language_name' })
 ```
 
 ### EVAL
@@ -153,7 +171,7 @@ Use the [WHERE](https://www.elastic.co/docs/reference/query-languages/esql/comma
 ```ruby
 query = Elastic::ESQL.from('sample')
 # => #<Elastic::ESQL:0x000073015ef041f0 @query={from: "sample"}>
-query.where('age > 18')
+query.where!('age > 18')
 #  => #<Elastic::ESQL:0x000073015ef041f0 @query={from: "sample", where: "age > 18"}>
 query.to_s
 # => "FROM sample | WHERE age > 18"

--- a/lib/elastic/change_point.rb
+++ b/lib/elastic/change_point.rb
@@ -32,7 +32,7 @@ module Elastic
     #   esql.change_point('my_column', key: 'my_key', type_name: 'spike', pvalue_name: 'pvalue')
     #
     # @see https://www.elastic.co/docs/reference/query-languages/esql/commands/processing-commands#esql-change_point
-    def change_point(column, key: nil, type_name: nil, pvalue_name: nil)
+    def change_point!(column, key: nil, type_name: nil, pvalue_name: nil)
       query = column
       query += " ON #{key}" unless key.nil?
       validate_type_name(type_name) if type_name
@@ -40,6 +40,10 @@ module Elastic
 
       @query[:change_point] = query
       self
+    end
+
+    def change_point(*params)
+      method_copy(:change_point, params)
     end
 
     private

--- a/lib/elastic/custom.rb
+++ b/lib/elastic/custom.rb
@@ -27,9 +27,16 @@ module Elastic
     #   esql.custom('| MY_VALUE = "test value"')
     #   esql.custom('| MY_VALUE = "test"').custom('| OTHER, VALUES')
     #
-    def custom(string)
+    def custom!(string)
       @custom << string
       self
+    end
+
+    def custom(*params)
+      esql = clone
+      esql.instance_variable_set('@custom', esql.instance_variable_get('@custom').clone)
+      esql.custom!(*params)
+      esql
     end
   end
 end

--- a/lib/elastic/dissect.rb
+++ b/lib/elastic/dissect.rb
@@ -31,11 +31,15 @@ module Elastic
     #   esql.dissect('a', '%{date} - %{msg} - %{ip}', ',')
     #
     # @see https://www.elastic.co/docs/reference/query-languages/esql/commands/processing-commands#esql-dissect
-    def dissect(input, pattern, separator = nil)
+    def dissect!(input, pattern, separator = nil)
       query = "#{input} \"\"\"#{pattern}\"\"\""
       query.concat " APPEND_SEPARATOR=\"#{separator}\"" if separator
       @query[:dissect] = query
       self
+    end
+
+    def dissect(input, pattern, separator = nil)
+      method_copy(:dissect, input, pattern, separator)
     end
   end
 end

--- a/lib/elastic/drop.rb
+++ b/lib/elastic/drop.rb
@@ -25,9 +25,13 @@ module Elastic
     #   esql.drop('column1')
     #   esql.drop('column1, column2, column3')
     # @see https://www.elastic.co/docs/reference/query-languages/esql/commands/processing-commands#esql-drop
-    def drop(*params)
+    def drop!(*params)
       @query[:drop] = params.join(', ')
       self
+    end
+
+    def drop(*params)
+      method_copy(:drop, params)
     end
   end
 end

--- a/lib/elastic/esql.rb
+++ b/lib/elastic/esql.rb
@@ -148,5 +148,14 @@ module Elastic
 
       false
     end
+
+    # Helper method to return a copy of the object when functions are called without `!`, so the
+    # object is not mutated.
+    def method_copy(name, *params)
+      esql = clone
+      esql.instance_variable_set('@query', esql.instance_variable_get('@query').clone)
+      esql.send("#{name}!", *params)
+      esql
+    end
   end
 end

--- a/lib/elastic/eval.rb
+++ b/lib/elastic/eval.rb
@@ -31,8 +31,12 @@ module Elastic
     #
     # @see https://www.elastic.co/docs/reference/query-languages/esql/commands/processing-commands#esql-eval
     #
-    def eval(params)
+    def eval!(params)
       hash_param(:eval, params)
+    end
+
+    def eval(params)
+      method_copy(:eval, params)
     end
   end
 end

--- a/lib/elastic/grok.rb
+++ b/lib/elastic/grok.rb
@@ -27,9 +27,13 @@ module Elastic
     # @example
     #   esql.grok('a', '%{date} - %{msg} - %{ip}')
     # @see https://www.elastic.co/docs/reference/query-languages/esql/esql-process-data-with-dissect-grok
-    def grok(input, pattern)
+    def grok!(input, pattern)
       @query[:grok] = "#{input} \"\"\"#{pattern}\"\"\""
       self
+    end
+
+    def grok(input, pattern)
+      method_copy(:grok, input, pattern)
     end
   end
 end

--- a/lib/elastic/keep.rb
+++ b/lib/elastic/keep.rb
@@ -23,9 +23,13 @@ module Elastic
     #   esql.keep('column1, column2')
     #   esql.keep('column1', 'column2')
     # @see https://www.elastic.co/docs/reference/query-languages/esql/commands/processing-commands#esql-keep
-    def keep(*params)
+    def keep!(*params)
       @query[:keep] = params.join(', ')
       self
+    end
+
+    def keep(*params)
+      method_copy(:keep, params)
     end
   end
 end

--- a/lib/elastic/limit.rb
+++ b/lib/elastic/limit.rb
@@ -20,9 +20,13 @@ module Elastic
   module Limit
     # @param [Integer] max_number_of_rows The maximum number of rows to return.
     # @see https://www.elastic.co/docs/reference/query-languages/esql/commands/processing-commands#esql-limit
-    def limit(max_number_of_rows)
+    def limit!(max_number_of_rows)
       @query[:limit] = max_number_of_rows
       self
+    end
+
+    def limit(max_number_of_rows)
+      method_copy(:limit, max_number_of_rows)
     end
   end
 end

--- a/lib/elastic/rename.rb
+++ b/lib/elastic/rename.rb
@@ -30,10 +30,14 @@ module Elastic
     #   esql.rename('first_name', 'fn')
     #   esql.rename({ first_name: 'fn', last_name: 'ln' })
     # @see https://www.elastic.co/docs/reference/query-languages/esql/commands/processing-commands#esql-rename
-    def rename(params)
+    def rename!(params)
       hash_param(:rename, params)
       @query[:rename] = @query[:rename].gsub('=', 'AS')
       self
+    end
+
+    def rename(params)
+      method_copy(:rename, params)
     end
   end
 end

--- a/lib/elastic/sort.rb
+++ b/lib/elastic/sort.rb
@@ -20,36 +20,58 @@ module Elastic
   module Sort
     # @param sort - The column to sort on.
     # @see https://www.elastic.co/docs/reference/query-languages/esql/commands/processing-commands#esql-sort
-    def sort(column)
+    def sort!(column)
       @query[:sort] = column
       self
     end
 
     # Sorts ascending, adds ASC to the sort function
-    def ascending
+    def ascending!
       sorting('ASC')
     end
 
     # Sorts descending, adds DESC to the sort function
-    def descending
+    def descending!
       sorting('DESC')
     end
 
     # Sort null values first using NULLS FIRST
     # By default, null values are treated as being larger than any other value.
     #
-    def nulls_first
+    def nulls_first!
       sorting('NULLS FIRST')
     end
 
     # Sort null values last using NULLS LAST
     #
-    def nulls_last
+    def nulls_last!
       sorting('NULLS LAST')
+    end
+
+    def sort(column)
+      method_copy(:sort, column)
+    end
+
+    def ascending
+      method_copy(:ascending)
+    end
+
+    def descending
+      method_copy(:descending)
+    end
+
+    def nulls_first
+      method_copy(:nulls_first)
+    end
+
+    def nulls_last
+      method_copy(:nulls_last)
     end
 
     alias asc ascending
     alias desc descending
+    alias asc! ascending!
+    alias desc! descending!
 
     private
 

--- a/lib/elastic/where.rb
+++ b/lib/elastic/where.rb
@@ -25,13 +25,17 @@ module Elastic
     #   esql.where('name LIKE "Something"')
     #
     # @see https://www.elastic.co/docs/reference/query-languages/esql/commands/processing-commands#esql-where
-    def where(expression)
+    def where!(expression)
       if @query[:where]
         @query[:where] += " AND #{expression}"
       else
         @query[:where] = expression
       end
       self
+    end
+
+    def where(expression)
+      method_copy(:where, expression)
     end
   end
 end

--- a/spec/change_point_spec.rb
+++ b/spec/change_point_spec.rb
@@ -22,18 +22,26 @@ describe Elastic::ESQL do
     let(:esql) { Elastic::ESQL.from('sample_data') }
 
     it 'accepts just column' do
-      esql.change_point('my_column')
+      esql.change_point!('my_column')
       expect(esql.query).to eq 'FROM sample_data | CHANGE_POINT my_column'
     end
 
     it 'accepts key' do
-      esql.change_point('my_column', key: 'my_key')
+      esql.change_point!('my_column', key: 'my_key')
       expect(esql.query).to eq 'FROM sample_data | CHANGE_POINT my_column ON my_key'
     end
 
     it 'accepts key, type name and pvalue' do
-      esql.change_point('my_column', key: 'my_key', type_name: 'spike', pvalue_name: 'pvalue')
+      esql.change_point!('my_column', key: 'my_key', type_name: 'spike', pvalue_name: 'pvalue')
       expect(esql.query).to eq 'FROM sample_data | CHANGE_POINT my_column ON my_key AS spike, pvalue'
+    end
+
+    it 'does not change the object when using change_point' do
+      esql.change_point('my_column', key: 'my_key', type_name: 'spike', pvalue_name: 'pvalue')
+      expect(
+        esql.change_point('my_column', key: 'my_key', type_name: 'spike', pvalue_name: 'pvalue').object_id
+      ).not_to eq esql.object_id
+      expect(esql.query).to eq 'FROM sample_data'
     end
   end
 end

--- a/spec/custom_string_spec.rb
+++ b/spec/custom_string_spec.rb
@@ -22,13 +22,30 @@ describe Elastic::ESQL do
     let(:esql) { Elastic::ESQL.from('sample_data') }
 
     it 'accepts a custom string as a parameter' do
-      esql.custom('| MY_VALUE = "test value"')
+      esql.custom!('| MY_VALUE = "test value"')
       expect(esql.query).to eq 'FROM sample_data | MY_VALUE = "test value"'
     end
 
     it 'accepts chaining custom strings' do
-      esql.custom('| MY_VALUE = "test value"').custom('| ANOTHER, VALUE')
+      esql.custom!('| MY_VALUE = "test value"').custom!('| ANOTHER, VALUE')
       expect(esql.query).to eq 'FROM sample_data | MY_VALUE = "test value" | ANOTHER, VALUE'
+    end
+
+    it 'accepts a custom string as a parameter' do
+      expect(esql.custom('| MY_VALUE = "test value"').to_s).to eq 'FROM sample_data | MY_VALUE = "test value"'
+      expect(esql.query).to eq 'FROM sample_data'
+    end
+
+    it 'accepts chaining custom strings with `custom`' do
+      expect(
+        esql.custom('| MY_VALUE = "test value"').custom('| ANOTHER, VALUE').to_s
+      ).to eq 'FROM sample_data | MY_VALUE = "test value" | ANOTHER, VALUE'
+    end
+
+    it 'does not mutate the original object when using `custom`' do
+      expect(
+        esql.custom('| MY_VALUE = "test value"').custom('| ANOTHER, VALUE').object_id
+      ).not_to eq esql.object_id
     end
   end
 end

--- a/spec/dissect_spec.rb
+++ b/spec/dissect_spec.rb
@@ -22,13 +22,18 @@ describe Elastic::ESQL do
     let(:esql) { Elastic::ESQL.from('sample_data') }
 
     it 'accepts input and pattern as parameters' do
-      esql.dissect('a', '%{date} - %{msg} - %{ip}')
+      esql.dissect!('a', '%{date} - %{msg} - %{ip}')
       expect(esql.query).to eq 'FROM sample_data | DISSECT a """%{date} - %{msg} - %{ip}"""'
     end
 
     it 'accepts separator parameter' do
-      esql.dissect('a', '%{date} - %{msg} - %{ip}', ',')
+      esql.dissect!('a', '%{date} - %{msg} - %{ip}', ',')
       expect(esql.query).to eq 'FROM sample_data | DISSECT a """%{date} - %{msg} - %{ip}""" APPEND_SEPARATOR=","'
+    end
+
+    it 'accepts input and pattern as parameters with `dissect`' do
+      esql.dissect('a', '%{date} - %{msg} - %{ip}', ',')
+      expect(esql.query).to eq 'FROM sample_data'
     end
   end
 end

--- a/spec/drop_spec.rb
+++ b/spec/drop_spec.rb
@@ -22,23 +22,30 @@ describe Elastic::ESQL do
     let(:esql) { Elastic::ESQL.from('sample_data') }
 
     it 'accepts 2 strings as a parameter' do
-      esql.drop('column1', 'column2')
+      esql.drop!('column1', 'column2')
       expect(esql.query).to eq 'FROM sample_data | DROP column1, column2'
     end
 
     it 'accepts a string as a parameter' do
-      esql.drop('column1')
+      esql.drop!('column1')
       expect(esql.query).to eq 'FROM sample_data | DROP column1'
     end
 
     it 'accepts a string with several columns as a parameter' do
-      esql.drop('column1, column2, column3')
+      esql.drop!('column1, column2, column3')
       expect(esql.query).to eq 'FROM sample_data | DROP column1, column2, column3'
     end
 
     it 'accepts backticks in column names as identifiers' do
-      esql.drop('`1.field`')
+      esql.drop!('`1.field`')
       expect(esql.query).to eq 'FROM sample_data | DROP `1.field`'
+    end
+
+    it 'accepts not mutating method drop' do
+      expect(esql.drop('field').query).to eq 'FROM sample_data | DROP field'
+      expect(esql.query).to eq 'FROM sample_data'
+      expect(esql.drop!('field').query).to eq 'FROM sample_data | DROP field'
+      expect(esql.query).to eq 'FROM sample_data | DROP field'
     end
   end
 end

--- a/spec/enrich_spec.rb
+++ b/spec/enrich_spec.rb
@@ -53,7 +53,7 @@ describe Elastic::ESQL do
     end
 
     it 'works fine when continuing chainging' do
-      esql.enrich('policy').sort('@timestamp')
+      esql.enrich('policy').sort!('@timestamp')
       expect(esql.to_s).to eq 'FROM sample_data | SORT @timestamp | ENRICH policy'
     end
   end

--- a/spec/esql_spec.rb
+++ b/spec/esql_spec.rb
@@ -30,8 +30,15 @@ describe Elastic::ESQL do
       expect(esql.from('something_else').query).to eq 'FROM something_else'
     end
 
-    it 'uses limit' do
-      expect(esql.limit(2).to_s).to eq 'FROM sample_data | LIMIT 2'
+    it 'uses limit!' do
+      expect(esql.limit!(2).to_s).to eq 'FROM sample_data | LIMIT 2'
+    end
+
+    it 'uses limit without changing' do
+      expect(esql.limit(4).to_s).to eq 'FROM sample_data | LIMIT 4'
+      expect(esql.to_s).to eq 'FROM sample_data'
+      esql.limit!(2)
+      expect(esql.to_s).to eq 'FROM sample_data | LIMIT 2'
     end
 
     it 'returns the full query' do
@@ -41,7 +48,7 @@ describe Elastic::ESQL do
     end
 
     it 'saves query data and returns with .query' do
-      esql.sort('@timestamp').ascending.limit(2).where('value > 10')
+      esql.sort!('@timestamp').ascending!.limit!(2).where!('value > 10')
       expect(
         esql.query
       ).to eq 'FROM sample_data | SORT @timestamp ASC | LIMIT 2 | WHERE value > 10'

--- a/spec/eval_spec.rb
+++ b/spec/eval_spec.rb
@@ -22,12 +22,20 @@ describe Elastic::ESQL do
     let(:esql) { Elastic::ESQL.from('sample_data') }
 
     it 'accepts a Hash as a parameter' do
-      esql.eval({ height_feet: 'height * 3.281', height_cm: 'height * 100' })
+      esql.eval!({ height_feet: 'height * 3.281', height_cm: 'height * 100' })
       expect(esql.query).to eq 'FROM sample_data | EVAL height_feet = height * 3.281, height_cm = height * 100'
     end
 
     it 'raises error if the parameters are wrong' do
-      expect { esql.eval('duration_ms', 'event_duration', 1000) }.to raise_error ArgumentError
+      expect { esql.eval!('duration_ms', 'event_duration', 1000) }.to raise_error ArgumentError
+    end
+
+    it 'does not change the object when using eval' do
+      esql.eval({ height_feet: 'height * 3.281', height_cm: 'height * 100' })
+      expect(
+        esql.eval({ height_feet: 'height * 3.281', height_cm: 'height * 100' }).object_id
+      ).not_to eq esql.object_id
+      expect(esql.query).to eq 'FROM sample_data'
     end
   end
 end

--- a/spec/grok_spec.rb
+++ b/spec/grok_spec.rb
@@ -22,8 +22,16 @@ describe Elastic::ESQL do
     let(:esql) { Elastic::ESQL.from('sample_data') }
 
     it 'accepts input and pattern as parameters' do
-      esql.grok('a', '%{date} - %{msg} - %{ip}')
+      esql.grok!('a', '%{date} - %{msg} - %{ip}')
       expect(esql.query).to eq 'FROM sample_data | GROK a """%{date} - %{msg} - %{ip}"""'
+    end
+
+    it 'does not change the object when using grok' do
+      esql.grok('a', '%{date} - %{msg} - %{ip}')
+      expect(
+        esql.grok('a', '%{date} - %{msg} - %{ip}').object_id
+      ).not_to eq esql.object_id
+      expect(esql.query).to eq 'FROM sample_data'
     end
   end
 end

--- a/spec/keep_spec.rb
+++ b/spec/keep_spec.rb
@@ -17,28 +17,38 @@
 
 require 'spec_helper'
 
+# rubocop:disable Metrics/BlockLength
 describe Elastic::ESQL do
   context 'KEEP' do
     let(:esql) { Elastic::ESQL.from('sample_data') }
 
     it 'accepts 2 strings as a parameter' do
-      esql.keep('column1', 'column2')
+      esql.keep!('column1', 'column2')
       expect(esql.query).to eq 'FROM sample_data | KEEP column1, column2'
     end
 
     it 'accepts a string as a parameter' do
-      esql.keep('column1')
+      esql.keep!('column1')
       expect(esql.query).to eq 'FROM sample_data | KEEP column1'
     end
 
     it 'accepts a string with several columns as a parameter' do
-      esql.keep('column1, column2, column3')
+      esql.keep!('column1, column2, column3')
       expect(esql.query).to eq 'FROM sample_data | KEEP column1, column2, column3'
     end
 
     it 'accepts backticks in column names as identifiers' do
-      esql.keep('`1.field`')
+      esql.keep!('`1.field`')
       expect(esql.query).to eq 'FROM sample_data | KEEP `1.field`'
+    end
+
+    it 'does not change the object when using keep' do
+      esql.keep('column1', 'column2')
+      expect(
+        esql.keep('column1, column2').object_id
+      ).not_to eq esql.object_id
+      expect(esql.query).to eq 'FROM sample_data'
     end
   end
 end
+# rubocop:enable Metrics/BlockLength

--- a/spec/rename_spec.rb
+++ b/spec/rename_spec.rb
@@ -22,8 +22,15 @@ describe Elastic::ESQL do
     let(:esql) { Elastic::ESQL.from('sample_data') }
 
     it 'accepts a Hash as a parameter' do
-      esql.rename({ first_name: 'fn', last_name: 'ln' })
+      esql.rename!({ first_name: 'fn', last_name: 'ln' })
       expect(esql.query).to eq 'FROM sample_data | RENAME first_name AS fn, last_name AS ln'
+    end
+
+    it 'does not mutate the object' do
+      expect(
+        esql.rename({ first_name: 'fn', last_name: 'ln' }).to_s
+      ).to eq 'FROM sample_data | RENAME first_name AS fn, last_name AS ln'
+      expect(esql.query).to eq 'FROM sample_data'
     end
   end
 end

--- a/spec/sort_spec.rb
+++ b/spec/sort_spec.rb
@@ -76,6 +76,29 @@ describe Elastic::ESQL do
           Elastic::ESQL.from('sample_data').sort('@timestamp').desc.to_s
         ).to eq 'FROM sample_data | SORT @timestamp DESC'
       end
+
+      it 'mutates with desc!' do
+        esql = Elastic::ESQL.from('sample_data')
+        esql.sort!('@timestamp').desc!
+        expect(esql.to_s).to eq 'FROM sample_data | SORT @timestamp DESC'
+      end
+
+      it 'mutates with asc!' do
+        esql = Elastic::ESQL.from('sample_data')
+        esql.sort!('@timestamp').asc!
+        expect(esql.to_s).to eq 'FROM sample_data | SORT @timestamp ASC'
+      end
+    end
+
+    context 'mutating the object' do
+      let(:esql) { Elastic::ESQL.from('sample_data') }
+      it 'changes the object when using !' do
+        esql.sort!('@timestamp').descending!
+        expect(esql.to_s).to eq 'FROM sample_data | SORT @timestamp DESC'
+
+        esql.nulls_first!
+        expect(esql.to_s).to eq 'FROM sample_data | SORT @timestamp DESC NULLS FIRST'
+      end
     end
   end
 end

--- a/spec/where_spec.rb
+++ b/spec/where_spec.rb
@@ -17,6 +17,7 @@
 
 require 'spec_helper'
 
+# rubocop:disable Metrics/BlockLength
 describe Elastic::ESQL do
   context 'WHERE' do
     let(:esql) { Elastic::ESQL.from('sample_data') }
@@ -39,5 +40,14 @@ describe Elastic::ESQL do
           .where('age > 18').query
       ).to eq 'FROM sample_data | WHERE first_name == "Juan" AND last_name == "Perez" AND age > 18'
     end
+
+    it 'mutates the query object' do
+      esql
+        .where!('first_name == "Juan"')
+        .where!('last_name == "Perez"')
+        .where!('age > 18').query
+      expect(esql.to_s).to eq 'FROM sample_data | WHERE first_name == "Juan" AND last_name == "Perez" AND age > 18'
+    end
   end
 end
+# rubocop:enable Metrics/BlockLength


### PR DESCRIPTION
Following Ruby's idiomatic naming of functions, there's now a `!` version of each function which mutates the object, and a version without `!` which returns a copy of the object.

Fixes #10